### PR TITLE
Fix: remove deprecated JSON JODA formats

### DIFF
--- a/app/uk/gov/hmrc/vatapi/models/models.scala
+++ b/app/uk/gov/hmrc/vatapi/models/models.scala
@@ -88,9 +88,11 @@ package object models {
     def trimNullable: Reads[Option[String]] = reads.map(_.map(_.trim))
   }
 
-  val pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+  val datePattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+
   implicit val dateFormat: Format[DateTime] = Format[DateTime](
-    Reads.jodaDateReads(pattern),
-    Writes.jodaDateWrites(pattern))
+    JodaReads.jodaDateReads(datePattern),
+    JodaWrites.jodaDateWrites(datePattern)
+  )
 
 }

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -30,7 +30,8 @@ private object AppDependencies {
     "uk.gov.hmrc" %% "auth-client" % "2.3.0",
     "uk.gov.hmrc" %% "domain" % "5.0.0",
     "uk.gov.hmrc" %% "play-hmrc-api" % "2.0.0",
-    "ai.x" %% "play-json-extensions" % "0.10.0"
+    "ai.x" %% "play-json-extensions" % "0.10.0",
+    "com.typesafe.play" %% "play-json-joda" % "2.6.7"
   )
 
   trait TestDependencies {


### PR DESCRIPTION
Please check if this change includes (or even requires) the following:

 - [ ] unit tests
 - [ ] functional tests
 - [ ] audit events
 - [ ] RAML documentation
 - [ ] logging
