### PR TITLE
Updated GET URL for DES VAT returns

### DIFF
--- a/app/uk/gov/hmrc/vatapi/connectors/VatReturnsConnector.scala
+++ b/app/uk/gov/hmrc/vatapi/connectors/VatReturnsConnector.scala
@@ -33,16 +33,22 @@ object VatReturnsConnector extends VatReturnsConnector {
 
 trait VatReturnsConnector extends BaseConnector {
 
-  lazy val vatReturnsUrl: String = s"${AppContext.desUrl}/enterprise/return/vat"
+  def post(vrn: Vrn, vatReturn: des.VatReturnDeclaration)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[VatReturnResponse] = {
 
-  def post(vrn: Vrn, vatReturn: des.VatReturnDeclaration)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[VatReturnResponse] =
+    val postUrl: String = s"${AppContext.desUrl}/enterprise/return/vat"
+
     httpPost[des.VatReturnDeclaration, VatReturnResponse](
-      url        = s"$vatReturnsUrl/$vrn",
-      elem       = vatReturn,
+      url = s"$postUrl/$vrn",
+      elem = vatReturn,
       toResponse = VatReturnResponse
     )
+  }
 
-  def query(vrn: Vrn, periodKey: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[VatReturnResponse] =
-    httpGet[VatReturnResponse](s"$vatReturnsUrl/$vrn?periodKey=${URLEncoder.encode(periodKey, "UTF-8")}", VatReturnResponse)
+  def query(vrn: Vrn, periodKey: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[VatReturnResponse] = {
+
+    val getUrl: String = s"${AppContext.desUrl}/vat/returns/vrn/$vrn?period-key=${URLEncoder.encode(periodKey, "UTF-8")}"
+
+    httpGet[VatReturnResponse](getUrl, VatReturnResponse)
+  }
 
 }

--- a/func/uk/gov/hmrc/ClientSubscriptionSimulationSpec.scala
+++ b/func/uk/gov/hmrc/ClientSubscriptionSimulationSpec.scala
@@ -11,7 +11,7 @@ class ClientSubscriptionSimulationSpec extends BaseFunctionalSpec {
       given()
         .userIsFullyAuthorisedForTheResource
         .when()
-        .get(s"/$vrn/returns/0001")
+        .get(s"/vat/returns/vrn/$vrn")
         .withHeaders(GovTestScenarioHeader, "CLIENT_OR_AGENT_NOT_AUTHORISED")
         .thenAssertThat()
         .statusIs(403)

--- a/func/uk/gov/hmrc/support/BaseFunctionalSpec.scala
+++ b/func/uk/gov/hmrc/support/BaseFunctionalSpec.scala
@@ -913,7 +913,7 @@ trait BaseFunctionalSpec extends TestApplication {
 
         def expectVatReturnRetrieveToFail(vrn: Vrn, code: String, reason: String = "Irrelevant"): Givens = {
           stubFor(
-            get(urlEqualTo(s"/enterprise/return/vat/$vrn?periodKey=0001"))
+            get(urlEqualTo(s"/vat/returns/vrn/$vrn?period-key=0001"))
               .willReturn(
                 aResponse()
                   .withStatus(403)
@@ -930,7 +930,7 @@ trait BaseFunctionalSpec extends TestApplication {
 
         def expectVatReturnSearchFor(vrn: Vrn, periodKey: String): Givens = {
           stubFor(
-            get(urlEqualTo(s"/enterprise/return/vat/$vrn?periodKey=$periodKey"))
+            get(urlEqualTo(s"/vat/returns/vrn/$vrn?period-key=$periodKey"))
               .willReturn(
                 aResponse()
                   .withStatus(200)
@@ -957,7 +957,7 @@ trait BaseFunctionalSpec extends TestApplication {
 
         def expectInvalidVatReturnSearchFor(vrn: Vrn, periodKey: String): Givens = {
           stubFor(
-            get(urlEqualTo(s"/enterprise/return/vat/$vrn?periodKey=$periodKey"))
+            get(urlEqualTo(s"/vat/returns/vrn/$vrn?period-key=$periodKey"))
               .willReturn(
                 aResponse()
                   .withStatus(200)
@@ -969,7 +969,7 @@ trait BaseFunctionalSpec extends TestApplication {
 
         def expectNonExistentVrnFor(vrn: Vrn, periodKey: String): Givens = {
           stubFor(
-            get(urlEqualTo(s"/enterprise/return/vat/$vrn?periodKey=$periodKey"))
+            get(urlEqualTo(s"/vat/returns/vrn/$vrn?period-key=$periodKey"))
               .willReturn(aResponse().withStatus(404))
           )
           givens

--- a/test/uk/gov/hmrc/vatapi/connectors/VatReturnsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/vatapi/connectors/VatReturnsConnectorSpec.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.domain.Vrn
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.vatapi.UnitSpec
 import uk.gov.hmrc.vatapi.assets.TestConstants.VatReturn._
-import uk.gov.hmrc.vatapi.config.WSHttp
+import uk.gov.hmrc.vatapi.config.{AppContext, WSHttp}
 import uk.gov.hmrc.vatapi.mocks.MockHttp
 import uk.gov.hmrc.vatapi.models.des
 import uk.gov.hmrc.vatapi.models.des.{DesError, DesErrorCode}
@@ -56,7 +56,7 @@ class VatReturnsConnectorSpec extends UnitSpec with OneAppPerSuite with MockitoS
 
   "VatReturnsConnector.post" should {
 
-    lazy val testUrl: String = TestVatReturnsConnector.vatReturnsUrl+s"/$testVrn"
+    lazy val testUrl: String = s"${AppContext.desUrl}/enterprise/return/vat/" + testVrn
     def result(requestBody: des.VatReturnDeclaration): Future[VatReturnResponse] = TestVatReturnsConnector.post(testVrn, requestBody)
 
     "return a VatReturnsResponse model with correct body in case of success" in {


### PR DESCRIPTION
Please check if this change includes (or even requires) the following:

 - [ N/A ] unit tests
 - [ Y ] functional tests
 - [ N/A ] audit events
 - [ N/A ] RAML documentation
 - [ N/A ] logging
