### PR TITLE
MTDSA-1529 View VAT returns should accept the response without the re…

### DIFF
--- a/app/uk/gov/hmrc/vatapi/models/des/VatReturn.scala
+++ b/app/uk/gov/hmrc/vatapi/models/des/VatReturn.scala
@@ -35,7 +35,7 @@ case class VatReturn(periodKey: String,
                      totalValueGoodsSuppliedExVAT: Amount,
                      totalAllAcquisitionsExVAT: Amount,
                      agentReferenceNumber: Option[String] = None,
-                     receivedAt: DateTime)
+                     receivedAt: Option[DateTime] = None)
 
 object VatReturn {
   implicit val reads: Format[VatReturn] = Json.format[VatReturn]

--- a/app/uk/gov/hmrc/vatapi/resources/ObligationsResource.scala
+++ b/app/uk/gov/hmrc/vatapi/resources/ObligationsResource.scala
@@ -36,6 +36,7 @@ object ObligationsResource extends BaseResource {
   private val connector = ObligationsConnector
 
   def retrieveObligations(vrn: Vrn, params: ObligationsQueryParams): Action[AnyContent] = APIAction(vrn).async { implicit request =>
+    logger.debug(s"[ObligationsResource][retrieveObligations] - Get Obligations")
     fromDes {
       for {
         response <- execute { _ => connector.get(vrn, params) }

--- a/func/uk/gov/hmrc/support/BaseFunctionalSpec.scala
+++ b/func/uk/gov/hmrc/support/BaseFunctionalSpec.scala
@@ -702,6 +702,32 @@ trait BaseFunctionalSpec extends TestApplication {
           givens
         }
 
+        def expectVatReturnSearchForWithoutReceivedAt(vrn: Vrn, periodKey: String): Givens = {
+          stubFor(
+            get(urlEqualTo(s"/vat/returns/vrn/$vrn?period-key=$periodKey"))
+              .willReturn(
+                aResponse()
+                  .withStatus(200)
+                  .withBody("""
+                    {
+                      "periodKey": "0001",
+                      "inboundCorrespondenceFromDate": "2017-01-01",
+                      "inboundCorrespondenceToDate": "2017-12-31",
+                      "vatDueSales": 100.25,
+                      "vatDueAcquisitions": 100.25,
+                      "vatDueTotal": 200.50,
+                      "vatReclaimedCurrPeriod": 100.25,
+                      "vatDueNet": 100.25,
+                      "totalValueSalesExVAT": 100,
+                      "totalValuePurchasesExVAT": 100,
+                      "totalValueGoodsSuppliedExVAT": 100,
+                      "totalAllAcquisitionsExVAT": 100
+                    }""")
+              )
+          )
+          givens
+        }
+
         def expectInvalidVatReturnSearchFor(vrn: Vrn, periodKey: String): Givens = {
           stubFor(
             get(urlEqualTo(s"/vat/returns/vrn/$vrn?period-key=$periodKey"))

--- a/func/uk/gov/hmrc/vatapi/resources/ValueAddedTaxReturnsSpec.scala
+++ b/func/uk/gov/hmrc/vatapi/resources/ValueAddedTaxReturnsSpec.scala
@@ -194,6 +194,26 @@ class ValueAddedTaxReturnsSpec extends BaseFunctionalSpec {
         .bodyHasPath("\\totalAcquisitionsExVAT", 100)
     }
 
+    "allow users to retrieve VAT returns without receivedAt field for last four years" in {
+      given()
+        .userIsFullyAuthorisedForTheResource
+        .des().vatReturns.expectVatReturnSearchForWithoutReceivedAt(vrn, "0001")
+        .when()
+        .get(s"/$vrn/returns/0001")
+        .thenAssertThat()
+        .statusIs(200)
+        .bodyHasPath("\\periodKey", "0001")
+        .bodyHasPath("\\vatDueSales", 100.25)
+        .bodyHasPath("\\vatDueAcquisitions", 100.25)
+        .bodyHasPath("\\totalVatDue", 200.50)
+        .bodyHasPath("\\vatReclaimedCurrPeriod", 100.25)
+        .bodyHasPath("\\netVatDue", 100.25)
+        .bodyHasPath("\\totalValueSalesExVAT", 100)
+        .bodyHasPath("\\totalValuePurchasesExVAT", 100)
+        .bodyHasPath("\\totalValueGoodsSuppliedExVAT", 100)
+        .bodyHasPath("\\totalAcquisitionsExVAT", 100)
+    }
+
     "return internal server error on malformed response" in {
       given()
         .userIsFullyAuthorisedForTheResource


### PR DESCRIPTION
…ceivedAt field.

Please check if this change includes (or even requires) the following:

 - [ ] unit tests
 - [ ] functional tests
 - [ ] audit events
 - [ ] RAML documentation
 - [ ] logging
