### PR TITLE
Removed `println` statement

### DIFF
--- a/app/uk/gov/hmrc/vatapi/services/AuthorisationService.scala
+++ b/app/uk/gov/hmrc/vatapi/services/AuthorisationService.scala
@@ -128,9 +128,8 @@ trait AuthorisationService {
     case _: InsufficientConfidenceLevel =>
       logger.warn(s"[AuthorisationService] [unauthorisedError] Client authorisation failed due to unsupported insufficient confidenceLevels.")
       Future.successful(Left(Forbidden(toJson(Errors.ClientOrAgentNotAuthorized))))
-    case ex: JsResultException =>
+    case _: JsResultException =>
       logger.warn(s"[AuthorisationService] [unauthorisedError] - Did not receive minimum data from Auth required for NRS Submission")
-      println(ex)
       Future.successful(Left(Forbidden(toJson(Errors.InternalServerError))))
     case exception@_ =>
       logger.warn(s"[AuthorisationService] [unauthorisedError] Client authorisation failed due to internal server error. auth-client exception was ${exception.getClass.getSimpleName}")


### PR DESCRIPTION
Please check if this change includes (or even requires) the following:

 - [ ] unit tests
 - [ ] functional tests
 - [ ] audit events
 - [ ] RAML documentation
 - [ ] logging
