### PR TITLE
modified RAML for obligations status parameter = optional

### DIFF
--- a/public/api/conf/1.0/application.raml
+++ b/public/api/conf/1.0/application.raml
@@ -86,7 +86,7 @@ traits:
            description: Which obligation statuses to return (O=Open, F=Fulfilled)
            type: string
            example: F
-           required: true
+           required: false
         responses:
           200:
             headers:


### PR DESCRIPTION
Please check if this change includes (or even requires) the following:

 - [ ] unit tests
 - [ ] functional tests
 - [ ] audit events
 - [ ] RAML documentation
 - [ ] logging
