### PR TITLE
Changed Retrieve VAT URL in connector to point to new IOF endpoint

### DIFF
--- a/app/uk/gov/hmrc/vatapi/config/AppContext.scala
+++ b/app/uk/gov/hmrc/vatapi/config/AppContext.scala
@@ -51,5 +51,5 @@ trait AppContext extends ServicesConfig {
     config.getString(s"$env.enrolments.identifier").getOrElse(throw new RuntimeException("identifier is not configured")),
     config.getString(s"$env.enrolments.auth-rule"))
 
-  lazy val vatHybridFeature = config.getBoolean(s"$env.feature-switch.des.hybrid").getOrElse(false)
+  lazy val vatHybridFeatureEnabled = config.getBoolean(s"$env.feature-switch.des.hybrid").getOrElse(false)
 }

--- a/app/uk/gov/hmrc/vatapi/connectors/VatReturnsConnector.scala
+++ b/app/uk/gov/hmrc/vatapi/connectors/VatReturnsConnector.scala
@@ -41,8 +41,11 @@ trait VatReturnsConnector extends BaseConnector {
 
     logger.debug(s"[VatReturnsConnector][post] - Submission for 9 box vat return for VRN: $vrn")
 
+    val desUrl = s"${appContext.desUrl}/enterprise/return/vat/$vrn"
+    val hybridUrl = s"${appContext.desUrl}/vat/traders/$vrn/returns"
+
     httpDesPostString[VatReturnResponse](
-      url = s"${retrieveDesUrl(vrn)}",
+      url = if (appContext.vatHybridFeatureEnabled) hybridUrl else desUrl,
       elem = vatReturn.toJsonString,
       toResponse = VatReturnResponse
     )
@@ -52,16 +55,12 @@ trait VatReturnsConnector extends BaseConnector {
 
     logger.debug(s"[VatReturnsConnector][query] - Retrieve vat returns for VRN: $vrn and periodKey: $periodKey")
 
-    val getUrl: String = s"${AppContext.desUrl}/vat/returns/vrn/$vrn?period-key=${URLEncoder.encode(periodKey, "UTF-8")}"
+    val desUrl = s"${appContext.desUrl}/vat/returns/vrn/$vrn"
+    val hybridUrl = s"${appContext.desUrl}/vat/traders/$vrn/returns"
+
+    val getUrl: String = s"${if (appContext.vatHybridFeatureEnabled) hybridUrl else desUrl}?period-key=${URLEncoder.encode(periodKey, "UTF-8")}"
 
     httpGet[VatReturnResponse](getUrl, VatReturnResponse)
-  }
-
-  def retrieveDesUrl(vrn: Vrn): String = {
-    appContext.vatHybridFeature match {
-      case true => s"${appContext.desUrl}/vat/traders/$vrn/returns"
-      case false => s"${appContext.desUrl}/enterprise/return/vat/$vrn"
-    }
   }
 
 }

--- a/test/uk/gov/hmrc/vatapi/connectors/VatReturnsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/vatapi/connectors/VatReturnsConnectorSpec.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.vatapi.connectors
 
+import java.net.URLEncoder
+
 import org.joda.time.DateTime
 import org.scalatestplus.play.OneAppPerSuite
 import play.api.http.Status._
@@ -41,6 +43,8 @@ class VatReturnsConnectorSpec extends UnitSpec with OneAppPerSuite
       override val http: WSHttp = mockHttp
       override val appContext = mockAppContext
     }
+    val testDesUrl = "test"
+    MockAppContext.desUrl.returns(testDesUrl)
   }
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
@@ -55,23 +59,20 @@ class VatReturnsConnectorSpec extends UnitSpec with OneAppPerSuite
       responseJson = Some(Json.toJson(DesError(DesErrorCode.INVALID_PAYLOAD, "Submission has not passed validation. Invalid parameter Payload.")))
     )
 
+
   "VatReturnsConnector.post" should {
 
     "return a VatReturnsResponse model with correct body in case of success" when {
 
-      val testDesUrl = "test"
-
       "pointing to the vat hybrid" in new Test {
-        MockAppContext.vatHybridFeature.thenReturn(true)
-        MockAppContext.desUrl.returns(testDesUrl)
+        MockAppContext.vatHybridFeatureEnabled.thenReturn(true)
         val testUrl: String = s"$testDesUrl/vat/traders/$testVrn/returns"
         setupMockHttpPostString(testUrl, desVatReturnDeclaration(testDateTime).toJsonString)(successResponse)
         await(connector.post(testVrn, desVatReturnDeclaration(testDateTime))) shouldBe VatReturnResponse(successResponse)
       }
 
       "pointing to the vat normal" in new Test {
-        MockAppContext.vatHybridFeature.thenReturn(false)
-        MockAppContext.desUrl.returns(testDesUrl)
+        MockAppContext.vatHybridFeatureEnabled.thenReturn(false)
         val testUrl: String = s"$testDesUrl/enterprise/return/vat/$testVrn"
         setupMockHttpPostString(testUrl, desVatReturnDeclaration(testDateTime).toJsonString)(successResponse)
         await(connector.post(testVrn, desVatReturnDeclaration(testDateTime))) shouldBe VatReturnResponse(successResponse)
@@ -80,22 +81,56 @@ class VatReturnsConnectorSpec extends UnitSpec with OneAppPerSuite
 
     "return a VatReturnsResponse with the correct error body when an error is retrieved from DES" when {
 
-      val testDesUrl = "test"
-
       "pointing to the vat hybrid" in new Test {
-        MockAppContext.vatHybridFeature.thenReturn(true)
-        MockAppContext.desUrl.returns(testDesUrl)
+        MockAppContext.vatHybridFeatureEnabled.thenReturn(true)
         val testUrl: String = s"$testDesUrl/vat/traders/$testVrn/returns"
         setupMockHttpPostString(testUrl, desVatReturnDeclaration(testDateTime).toJsonString)(invalidPayloadResponse)
         await(connector.post(testVrn, desVatReturnDeclaration(testDateTime))) shouldBe VatReturnResponse(invalidPayloadResponse)
       }
 
       "pointing to the vat normal" in new Test {
-        MockAppContext.vatHybridFeature.thenReturn(false)
-        MockAppContext.desUrl.returns(testDesUrl)
+        MockAppContext.vatHybridFeatureEnabled.thenReturn(false)
         val testUrl: String = s"$testDesUrl/enterprise/return/vat/$testVrn"
         setupMockHttpPostString(testUrl, desVatReturnDeclaration(testDateTime).toJsonString)(invalidPayloadResponse)
         await(connector.post(testVrn, desVatReturnDeclaration(testDateTime))) shouldBe VatReturnResponse(invalidPayloadResponse)
+      }
+    }
+
+    "VatReturnsConnector.query" should {
+
+      val periodKey = "test"
+      "return a VatReturnsResponse model in case of success" when {
+
+        "pointing to the vat hybrid" in new Test {
+          MockAppContext.vatHybridFeatureEnabled.thenReturn(true)
+          val testUrl: String = s"$testDesUrl/vat/traders/$testVrn/returns?period-key=${URLEncoder.encode(periodKey, "UTF-8")}"
+          setupMockHttpGet(testUrl)(successResponse)
+          await(connector.query(testVrn, periodKey)) shouldBe VatReturnResponse(successResponse)
+        }
+
+        "pointing to the vat normal" in new Test {
+          MockAppContext.vatHybridFeatureEnabled.thenReturn(false)
+          val testUrl: String = s"$testDesUrl/vat/returns/vrn/$testVrn?period-key=${URLEncoder.encode(periodKey, "UTF-8")}"
+          setupMockHttpGet(testUrl)(successResponse)
+          await(connector.query(testVrn, periodKey)) shouldBe VatReturnResponse(successResponse)
+        }
+      }
+
+      "return a VatReturnsResponse with the correct error body when an error is retrieved from DES" when {
+
+        "pointing to the vat hybrid" in new Test {
+          MockAppContext.vatHybridFeatureEnabled.thenReturn(true)
+          val testUrl: String = s"$testDesUrl/vat/traders/$testVrn/returns?period-key=${URLEncoder.encode(periodKey, "UTF-8")}"
+          setupMockHttpGet(testUrl)(invalidPayloadResponse)
+          await(connector.query(testVrn, periodKey)) shouldBe VatReturnResponse(invalidPayloadResponse)
+        }
+
+        "pointing to the vat normal" in new Test {
+          MockAppContext.vatHybridFeatureEnabled.thenReturn(false)
+          val testUrl: String = s"$testDesUrl/vat/returns/vrn/$testVrn?period-key=${URLEncoder.encode(periodKey, "UTF-8")}"
+          setupMockHttpGet(testUrl)(invalidPayloadResponse)
+          await(connector.query(testVrn, periodKey)) shouldBe VatReturnResponse(invalidPayloadResponse)
+        }
       }
     }
   }

--- a/test/uk/gov/hmrc/vatapi/mocks/config/MockAppContext.scala
+++ b/test/uk/gov/hmrc/vatapi/mocks/config/MockAppContext.scala
@@ -29,7 +29,7 @@ trait MockAppContext extends Mock { _: Suite =>
     def desUrl: OngoingStubbing[String] = when(mockAppContext.desUrl)
     def desToken: OngoingStubbing[String] = when(mockAppContext.desToken)
     def desEnv: OngoingStubbing[String] = when(mockAppContext.desEnv)
-    def vatHybridFeature: OngoingStubbing[Boolean] = when(mockAppContext.vatHybridFeature)
+    def vatHybridFeatureEnabled: OngoingStubbing[Boolean] = when(mockAppContext.vatHybridFeatureEnabled)
   }
 
   override protected def beforeEach(): Unit = {


### PR DESCRIPTION
Please check if this change includes (or even requires) the following:

 - [ ] unit tests
 - [ ] functional tests
 - [ ] audit events
 - [ ] RAML documentation
 - [ ] logging
