### PR TITLE
Removed text ", which must be URL-encoded" from periodKey schema docs…

### DIFF
--- a/public/api/conf/1.0/schemas/GetVatReturn.json
+++ b/public/api/conf/1.0/schemas/GetVatReturn.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "periodKey": {
-      "description": "The ID code for the period that this obligation belongs to. The format is a string of four alphanumeric characters. Occasionally the format includes the # symbol, which must be URL-encoded.",
+      "description": "The ID code for the period that this obligation belongs to. The format is a string of four alphanumeric characters. Occasionally the format includes the # symbol.",
       "type": "string",
       "minLength": 4,
       "maxLength": 4,

--- a/public/api/conf/1.0/schemas/Obligation.json
+++ b/public/api/conf/1.0/schemas/Obligation.json
@@ -32,7 +32,7 @@
     },
     "periodKey": {
       "title": "Period Key",
-      "description": "The ID code for the period that this obligation belongs to. The format is a string of four alphanumeric characters. Occasionally the format includes the # symbol, which must be URL-encoded.",
+      "description": "The ID code for the period that this obligation belongs to. The format is a string of four alphanumeric characters. Occasionally the format includes the # symbol.",
       "type": "string",
       "example": "18AD, 18A1, #001"
     }

--- a/public/api/conf/1.0/schemas/VatReturnDeclaration.json
+++ b/public/api/conf/1.0/schemas/VatReturnDeclaration.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "periodKey": {
-      "description": "The ID code for the period that this obligation belongs to. The format is a string of four alphanumeric characters. Occasionally the format includes the # symbol, which must be URL-encoded.",
+      "description": "The ID code for the period that this obligation belongs to. The format is a string of four alphanumeric characters. Occasionally the format includes the # symbol.",
       "type": "string",
       "minLength": 4,
       "maxLength": 4,


### PR DESCRIPTION
…, as it only applies if passed in the url, and causes errors if encoded in the json


