### PR TITLE
Doc corrections for liabilities and payments

### DIFF
--- a/public/api/conf/1.0/scenarios/vat-liabilities-scenarios.md
+++ b/public/api/conf/1.0/scenarios/vat-liabilities-scenarios.md
@@ -17,4 +17,4 @@
                 </tr>
     </tbody>
 </table>
-<p>The 'to' date of the liability must fall within the date range provided.</p>
+<p>The 'to' date of the liability will fall within the date range provided.</p>

--- a/public/api/conf/1.0/scenarios/vat-obligation-scenarios.md
+++ b/public/api/conf/1.0/scenarios/vat-obligation-scenarios.md
@@ -16,7 +16,6 @@
             <td><p>Simulates the scenario where the client has quarterly obligations and none are fulfilled</p></td>
         </tr>
         <tr>
-        <tr>
             <td><p>QUARTERLY_ONE_MET</p></td>
             <td><p>Simulates the scenario where the client has quarterly obligations and one is fulfilled</p></td>
         </tr>

--- a/public/api/conf/1.0/scenarios/vat-payments-scenarios.md
+++ b/public/api/conf/1.0/scenarios/vat-payments-scenarios.md
@@ -17,4 +17,4 @@
                 </tr>
     </tbody>
 </table>
-<p>The 'to' date of the payment must fall within the date range provided.</p>
+<p>The 'received' date of the payment will fall within the date range provided.</p>


### PR DESCRIPTION
- corrected 'to' date in payment to 'received'
- changed word 'must' to 'will', as this text describes what will be returned from the service, not what is expected from the client
