### PR TITLE
[DL-9065] Updated the appealLevel enum for late payment penalties in …

### DIFF
--- a/resources/public/api/conf/1.0/schemas/penalties/Penalties.json
+++ b/resources/public/api/conf/1.0/schemas/penalties/Penalties.json
@@ -410,7 +410,7 @@
                       "description": "The level of appeal.",
                       "type": "string",
                       "example": "appeal to HMRC",
-                      "enum": ["appeal-to-HMRC", "statutory-review", "appeal-first-tier-tribunal"]
+                      "enum": ["statutory-review", "appeal-first-tier-tribunal"]
                     }
                   },
                   "required": ["appealStatus", "appealLevel"],


### PR DESCRIPTION
…the schema for the penalties endpoint. The 'appeal-to-HMRC' value has been removed, to make the set of values consistent with the appealLevel enum for late submission penalties.